### PR TITLE
Move development dependencies to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rubocop-rspec'
+gem 'rake'
+gem 'rubygems-tasks'
+
 group :test do
   gem 'rspec'
   gem 'rspec-its'

--- a/the_schema_is.gemspec
+++ b/the_schema_is.gemspec
@@ -22,8 +22,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport' # it is a plugin for ActiveRecord anyways, and we need perfectly same inflection
   s.add_runtime_dependency 'memoist'
   s.add_runtime_dependency 'memo_wise'
-
-  s.add_development_dependency 'rubocop-rspec'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rubygems-tasks'
 end


### PR DESCRIPTION
No particular reason, apart from the fact that this is the pattern that I generally follow in my gems, which sort of has to do with the fact that I think of the gemspec as being related to distribution of the gem, and the development dependencies are, by definition, not related to the gem's distribution.